### PR TITLE
changed to use platform

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
     implementation(kotlin("stdlib", "1.5.0"))
 
     // Add shrinkwrap resolver
-    implementation("org.jboss.shrinkwrap.resolver:shrinkwrap-resolver-depchain:3.1.4")
+    implementation(platform("org.jboss.shrinkwrap.resolver:shrinkwrap-resolver-depchain:3.1.4"))
 
     // Use the kotlin test library
     testImplementation("io.kotest:kotest-assertions-core:4.6.3")


### PR DESCRIPTION
As this is a bom it [should use](https://docs.gradle.org/current/userguide/migrating_from_maven.html#migmvn:using_boms) even though it seem this doesn't give any errors here it does when trying to use this project in a maven build.